### PR TITLE
Fix marshmallow dependency

### DIFF
--- a/1_session-install-deps/requirements.txt
+++ b/1_session-install-deps/requirements.txt
@@ -1,4 +1,5 @@
 pandas==2.0.3
+marshmallow==3.26.1
 milvus==2.2.8
 pymilvus==2.2.8
 gradio==4.44.1


### PR DESCRIPTION
## Summary
- pin `marshmallow` to 3.26.1 in requirements to avoid errors with deprecated attributes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68405d862e4483309bd872d2b7a9fbf7